### PR TITLE
fix make check, add {{cmd}} variable to help message

### DIFF
--- a/examples/conan.js
+++ b/examples/conan.js
@@ -76,7 +76,7 @@ Conan.prototype.do_crush.help = (
     'Crush your enemies.\n'
     + '\n'
     + 'Usage:\n'
-    + '     {{name}} crush [OPTIONS] [ENEMIES...]\n'
+    + '     {{name}} {{cmd}} [OPTIONS] [ENEMIES...]\n'
     + '\n'
     + '{{options}}'
 );
@@ -90,7 +90,7 @@ Conan.prototype.do_completion.help = (
     'Print bash completion.\n'
     + '\n'
     + 'Usage:\n'
-    + '     {{name}} completion\n'
+    + '     {{name}} {{cmd}}\n'
     + '\n'
     + '{{options}}'
 );
@@ -110,7 +110,7 @@ Conan.prototype.do_see.help = (
     'See them driven before you.\n'
     + '\n'
     + 'Usage:\n'
-    + '     {{name}} see [OPTIONS] [ENEMIES...]\n'
+    + '     {{name}} {{cmd}} [OPTIONS] [ENEMIES...]\n'
     + '\n'
     + '{{options}}'
 );

--- a/lib/cmdln.js
+++ b/lib/cmdln.js
@@ -82,7 +82,7 @@ function objMerge(/* ... */) {
 
 // Replace {{variable}} in `s` with the template data in `d`.
 function renderTemplate(s, d) {
-    return s.replace(/{{([a-zA-Z]+)}}/g, function(match, key) {
+    return s.replace(/{{([a-zA-Z]+)}}/g, function (match, key) {
         return d.hasOwnProperty(key) ? d[key] : match;
     });
 }
@@ -699,6 +699,7 @@ Cmdln.prototype.helpFromSubcmd = function helpFromSubcmd(alias) {
     } else {
         var help = handler.help;
         help = help.replace(/{{name}}/g, this.name);
+        help = help.replace(/{{cmd}}/g, alias);
         if (~help.indexOf('{{options}}') && handler.options) {
             var parser = new dashdash.Parser({options: handler.options});
             var helpOpts = (handler.helpOpts


### PR DESCRIPTION
I'm adding filter support to `imgadm avail` (see https://github.com/joyent/smartos-live/issues/460) and need to document it in 1. the command and 2. the man page.  The commands documentation is stored in a single variable here

https://github.com/joyent/smartos-live/blob/master/src/img/lib/cli.js#L139-L157

Notice that the first line says "`imgadm list -j`".  I would like to have it say `imgadm list -j` when `imgadm list -h` is run, and `imgadm avail -j` when `imgadm avail -h` is run.  ie. it makes sense to have the variable have `imgadm {{cmd}} -j` and then be rendered by the `.help` method when invoked on the CLI.