### PR TITLE
assertion fails in the presence of finale option

### DIFF
--- a/lib/cmdln.js
+++ b/lib/cmdln.js
@@ -1405,7 +1405,7 @@ function main(cli, options) {
     if (options.hasOwnProperty('finale')) {
         assert.ok(VALID_FINALES.indexOf(options.finale) !== -1,
             format('invalid options.finale "%s": valid values are "%s"',
-                options.finale, '", "'.join(VALID_FINALES)));
+                options.finale, VALID_FINALES.join('", "')));
         finale = options.finale
     } else {
         finale = 'softexit';


### PR DESCRIPTION
Before:
TypeError: "", "".join is not a function

After:
AssertionError: invalid options.finale "foobar": valid values are "softexit", "exit", "callback", "none"
